### PR TITLE
Split Collectors by metric

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+**Why is this pull request necessary, and what does it do**?
+
+**Special notes for your reviewer**:

--- a/collector/common.go
+++ b/collector/common.go
@@ -53,8 +53,8 @@ func NewGCPClient(ctx context.Context, scope string) (client *http.Client, err e
 		googleClient.Transport,
 		rehttp.RetryAll(
 			rehttp.RetryMaxRetries(GCPMaxRetries),
-			rehttp.RetryStatuses(GCPRetryStatuses...)), // Cloud support suggests retrying on 503 errors
-		rehttp.ExpJitterDelay(GCPBackoffJitterBase, GCPMaxBackoffDuration), // Set timeout to <10s as that is Prometheus' default timeout
+			rehttp.RetryStatuses(GCPRetryStatuses...)),
+		rehttp.ExpJitterDelay(GCPBackoffJitterBase, GCPMaxBackoffDuration),
 	)
 	return googleClient, nil
 }

--- a/collector/common_test.go
+++ b/collector/common_test.go
@@ -1,7 +1,6 @@
 package collector
 
 import (
-	"context"
 	"os"
 	"testing"
 
@@ -30,25 +29,6 @@ func TestGetGCPZoneFromURL(t *testing.T) {
 		r := GetGCPZoneFromURL(log.NewJSONLogger(os.Stdout), tc.input)
 		if r != tc.expected {
 			t.Errorf("%s want %s got %s instead", tc.desc, tc.expected, r)
-		}
-	}
-}
-
-func TestNewGCPClient(t *testing.T) {
-	cases := []struct {
-		desc  string
-		input string
-	}{
-		{
-			"Should return a new scoped GCP Client",
-			"https://www.googleapis.com/auth/cloud-platform",
-		},
-	}
-
-	for _, tc := range cases {
-		_, err := NewGCPClient(context.Background(), tc.input)
-		if err != nil {
-			t.Errorf("%s got %+v", tc.desc, err)
 		}
 	}
 }

--- a/collector/common_test.go
+++ b/collector/common_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -29,6 +30,25 @@ func TestGetGCPZoneFromURL(t *testing.T) {
 		r := GetGCPZoneFromURL(log.NewJSONLogger(os.Stdout), tc.input)
 		if r != tc.expected {
 			t.Errorf("%s want %s got %s instead", tc.desc, tc.expected, r)
+		}
+	}
+}
+
+func TestNewGCPClient(t *testing.T) {
+	cases := []struct {
+		desc  string
+		input string
+	}{
+		{
+			"Should return a new scoped GCP Client",
+			"https://www.googleapis.com/auth/cloud-platform",
+		},
+	}
+
+	for _, tc := range cases {
+		_, err := NewGCPClient(context.Background(), tc.input)
+		if err != nil {
+			t.Errorf("%s got %+v", tc.desc, err)
 		}
 	}
 }

--- a/collector/gce_is_disk_attached.go
+++ b/collector/gce_is_disk_attached.go
@@ -29,7 +29,6 @@ func init() {
 	registerCollector("gce_is_disk_attached", defaultEnabled, NewIsDiskAttachedCollector)
 }
 
-// NewIsDiskAttachedCollector returns a new Collector exposing gce_is_disk_attached metrics
 func NewIsDiskAttachedCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
 	ctx := context.Background()
 	gcpClient, err := NewGCPClient(ctx, compute.ComputeReadonlyScope)
@@ -50,9 +49,7 @@ func NewIsDiskAttachedCollector(logger log.Logger, project string, monitoredRegi
 	}, nil
 }
 
-// Update will run each time the metrics endpoint is requested
 func (e *GCEIsDiskAttachedCollector) Update(ch chan<- prometheus.Metric) error {
-	// To protect metrics from concurrent collects.
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -87,7 +84,6 @@ func (e *GCEIsDiskAttachedCollector) Update(ch chan<- prometheus.Metric) error {
 		wgZones.Wait()
 	}
 
-	// Disk usage metrics
 	for _, disk := range disks {
 		isAttached := float64(len(disk.Users))
 		ch <- prometheus.MustNewConstMetric(

--- a/collector/gce_is_machine_running.go
+++ b/collector/gce_is_machine_running.go
@@ -29,7 +29,6 @@ func init() {
 	registerCollector("gce_is_machine_running", defaultEnabled, NewGCEIsMachineRunningCollector)
 }
 
-// NewGCEIsMachineRunningCollector returns a new Collector exposing gce_is_machine_running metrics
 func NewGCEIsMachineRunningCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
 	ctx := context.Background()
 	gcpClient, err := NewGCPClient(ctx, compute.ComputeReadonlyScope)
@@ -50,9 +49,7 @@ func NewGCEIsMachineRunningCollector(logger log.Logger, project string, monitore
 	}, nil
 }
 
-// Update will run each time the metrics endpoint is requested
 func (e *GCEIsMachineRunningCollector) Update(ch chan<- prometheus.Metric) error {
-	// Protects metrics from concurrent collects.
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -87,7 +84,6 @@ func (e *GCEIsMachineRunningCollector) Update(ch chan<- prometheus.Metric) error
 		wgZones.Wait()
 	}
 
-	// VM usage metrics
 	for _, vm := range vms {
 		var isRunning float64
 		if vm.Status == "RUNNING" {

--- a/collector/gce_is_machine_running.go
+++ b/collector/gce_is_machine_running.go
@@ -1,0 +1,109 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+var (
+	isMachineRunning = prometheus.NewDesc("gce_is_machine_running", "tells whether the VM is running", []string{"project", "zone", "name"}, nil)
+)
+
+type GCEIsMachineRunningCollector struct {
+	logger           log.Logger
+	service          *compute.Service
+	project          string
+	monitoredRegions []string
+	mutex            sync.RWMutex
+}
+
+func init() {
+	registerCollector("gce_is_machine_running", defaultEnabled, NewGCEIsMachineRunningCollector)
+}
+
+// NewGCEIsMachineRunningCollector returns a new Collector exposing gce_is_machine_running metrics
+func NewGCEIsMachineRunningCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
+	ctx := context.Background()
+	gcpClient, err := NewGCPClient(ctx, compute.ComputeReadonlyScope)
+	if err != nil {
+		level.Error(logger).Log("msg", "Unable to create GCP Client", "err", err)
+	}
+
+	computeService, err := compute.NewService(ctx, option.WithHTTPClient(gcpClient))
+	if err != nil {
+		level.Error(logger).Log("msg", "Unable to create service", "err", err)
+	}
+
+	return &GCEIsMachineRunningCollector{
+		logger:           logger,
+		service:          computeService,
+		project:          project,
+		monitoredRegions: monitoredRegions,
+	}, nil
+}
+
+// Update will run each time the metrics endpoint is requested
+func (e *GCEIsMachineRunningCollector) Update(ch chan<- prometheus.Metric) error {
+	// Protects metrics from concurrent collects.
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	regionList, err := e.service.Regions.List(e.project).Do()
+	if err != nil {
+		level.Error(e.logger).Log("msg", fmt.Sprintf("Failure when querying %s regions", e.project), "err", err)
+		regionList = nil
+	}
+
+	vms := []*compute.Instance{}
+
+	for _, r := range regionList.Items {
+		if !lo.Contains(e.monitoredRegions, r.Name) {
+			continue
+		}
+
+		var wgZones sync.WaitGroup
+		wgZones.Add(len(r.Zones))
+
+		for _, z := range r.Zones {
+			zone := GetGCPZoneFromURL(e.logger, z)
+			ch := make(chan struct{})
+			go func(ch chan struct{}) {
+				regionalInstances, err := e.service.Instances.List(e.project, zone).Do()
+				if err != nil {
+					level.Error(e.logger).Log("msg", fmt.Sprintf("error requesting machines for project %s in zone %s", e.project, zone), "err", err)
+				}
+				vms = append(vms, regionalInstances.Items...)
+				wgZones.Done()
+			}(ch)
+		}
+		wgZones.Wait()
+	}
+
+	// VM usage metrics
+	for _, vm := range vms {
+		var isRunning float64
+		if vm.Status == "RUNNING" {
+			isRunning = 1.0
+		} else {
+			isRunning = 0
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			isMachineRunning,
+			prometheus.GaugeValue,
+			isRunning,
+			e.project,
+			GetGCPZoneFromURL(e.logger, vm.Zone),
+			vm.Name)
+	}
+
+	return nil
+}

--- a/collector/gce_is_old_snapshot.go
+++ b/collector/gce_is_old_snapshot.go
@@ -32,7 +32,6 @@ func init() {
 	registerCollector("gce_is_old_snapshot", defaultEnabled, NewGCEIsOldSnapshotCollector)
 }
 
-// NewGCEIsOldSnapshotCollector returns a new Collector exposing gce_disk_has_old_snapshot metrics
 func NewGCEIsOldSnapshotCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
 	ctx := context.Background()
 	gcpClient, err := NewGCPClient(ctx, compute.ComputeReadonlyScope)
@@ -53,9 +52,7 @@ func NewGCEIsOldSnapshotCollector(logger log.Logger, project string, monitoredRe
 	}, nil
 }
 
-// Update will run each time the metrics endpoint is requested
 func (e *GCEIsOldSnapshotCollector) Update(ch chan<- prometheus.Metric) error {
-	// Protects metrics from concurrent collects.
 	e.mutex.Lock()
 	defer e.mutex.Unlock()
 
@@ -64,15 +61,12 @@ func (e *GCEIsOldSnapshotCollector) Update(ch chan<- prometheus.Metric) error {
 		level.Error(e.logger).Log("msg", fmt.Sprintf("error requesting disk snapshots for project %s", e.project), "err", err)
 	}
 
-	// Snapshots metrics
 	sort.Slice(snapshots.Items, func(i, j int) bool {
 		return snapshots.Items[i].SourceDiskId < snapshots.Items[j].SourceDiskId
 	})
 
 	reportedSnapshots := []string{}
 	for k, snapshot := range snapshots.Items {
-
-		level.Info(e.logger).Log("disk", snapshot.SourceDisk)
 		if lo.Contains(reportedSnapshots, snapshot.Name) {
 			continue
 		}

--- a/collector/gce_is_old_snapshot.go
+++ b/collector/gce_is_old_snapshot.go
@@ -1,0 +1,128 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+var (
+	isOldSnapshot = prometheus.NewDesc("gce_is_old_snapshot", "tells whether the Disk has unnecessary old snapshots", []string{"project", "disk", "snapshot"}, nil)
+)
+
+type GCEIsOldSnapshotCollector struct {
+	logger           log.Logger
+	service          *compute.Service
+	project          string
+	monitoredRegions []string
+	mutex            sync.RWMutex
+}
+
+func init() {
+	registerCollector("gce_is_old_snapshot", defaultEnabled, NewGCEIsOldSnapshotCollector)
+}
+
+// NewGCEIsOldSnapshotCollector returns a new Collector exposing gce_disk_has_old_snapshot metrics
+func NewGCEIsOldSnapshotCollector(logger log.Logger, project string, monitoredRegions []string) (Collector, error) {
+	ctx := context.Background()
+	gcpClient, err := NewGCPClient(ctx, compute.ComputeReadonlyScope)
+	if err != nil {
+		level.Error(logger).Log("msg", "Unable to create GCP Client", "err", err)
+	}
+
+	computeService, err := compute.NewService(ctx, option.WithHTTPClient(gcpClient))
+	if err != nil {
+		level.Error(logger).Log("msg", "Unable to create service", "err", err)
+	}
+
+	return &GCEIsOldSnapshotCollector{
+		logger:           logger,
+		service:          computeService,
+		project:          project,
+		monitoredRegions: monitoredRegions,
+	}, nil
+}
+
+// Update will run each time the metrics endpoint is requested
+func (e *GCEIsOldSnapshotCollector) Update(ch chan<- prometheus.Metric) error {
+	// Protects metrics from concurrent collects.
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	snapshots, err := e.service.Snapshots.List(e.project).Do()
+	if err != nil {
+		level.Error(e.logger).Log("msg", fmt.Sprintf("error requesting disk snapshots for project %s", e.project), "err", err)
+	}
+
+	// Snapshots metrics
+	sort.Slice(snapshots.Items, func(i, j int) bool {
+		return snapshots.Items[i].SourceDiskId < snapshots.Items[j].SourceDiskId
+	})
+
+	reportedSnapshots := []string{}
+	for k, snapshot := range snapshots.Items {
+
+		level.Info(e.logger).Log("disk", snapshot.SourceDisk)
+		if lo.Contains(reportedSnapshots, snapshot.Name) {
+			continue
+		}
+
+		if k < len(snapshots.Items)-1 {
+			next := snapshots.Items[k+1]
+			if snapshot.SourceDiskId == next.SourceDiskId {
+				if snapshot.CreationTimestamp < next.CreationTimestamp {
+					ch <- prometheus.MustNewConstMetric(
+						isOldSnapshot,
+						prometheus.GaugeValue,
+						1,
+						e.project,
+						GetDiskNameFromURL(e.logger, snapshot.SourceDisk),
+						snapshot.Name)
+					reportedSnapshots = append(reportedSnapshots, snapshot.Name)
+
+				} else {
+					ch <- prometheus.MustNewConstMetric(
+						isOldSnapshot,
+						prometheus.GaugeValue,
+						1,
+						e.project,
+						GetDiskNameFromURL(e.logger, next.SourceDisk),
+						next.Name)
+					reportedSnapshots = append(reportedSnapshots, next.Name)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func GetDiskNameFromURL(logger log.Logger, z string) string {
+	u, err := url.Parse(z)
+	if err != nil {
+
+		level.Error(logger).Log("msg", "error parsing Zone name", "err", err)
+	}
+
+	parts := strings.Split(u.Path, "/")
+
+	var disk string
+	for i := 0; i < len(parts); i++ {
+		if parts[i] == "disks" {
+			disk = parts[i+1]
+			i++
+		}
+	}
+
+	return disk
+}

--- a/collector/gce_is_old_snapshot_test.go
+++ b/collector/gce_is_old_snapshot_test.go
@@ -1,0 +1,34 @@
+package collector
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-kit/log"
+)
+
+func TestGetDiskNameFromURL(t *testing.T) {
+	cases := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			"Should return empty",
+			"https://someurl/",
+			"",
+		},
+		{
+			"Should return xxx",
+			"https://www.googleapis.com/compute/v1/projects/project/zones/us-central1-c/disks/disk",
+			"disk",
+		},
+	}
+
+	for _, tc := range cases {
+		r := GetDiskNameFromURL(log.NewJSONLogger(os.Stdout), tc.input)
+		if r != tc.expected {
+			t.Errorf("%s want %s got %s instead", tc.desc, tc.expected, r)
+		}
+	}
+}


### PR DESCRIPTION
**Why is this pull request necessary, and what does it do**?
To improve scraping performance and establish a more meaningful name to exposed metrics. This pull request parallelizes the access to compute engine resources and rename metrics to:

```bash
# Old snapshot detected
gce_is_old_snapshot{disk="diskName",project="gcp-project",snapshot="snapshotName"} 1

# Idle machine detected
gce_is_machine_running{name="machineName",project="gcp-project",zone="us-central1-a"} 0

# Idle disk detected
gce_is_disk_attached{name="diskName",project="gcp-project",zone="us-central1-a"} 0
```

**Special notes for your reviewer**:
Closes #3 
